### PR TITLE
Add fontbakery CI testing of static instance and variable font builds

### DIFF
--- a/.github/workflows/fontbakery-ci.yml
+++ b/.github/workflows/fontbakery-ci.yml
@@ -1,0 +1,40 @@
+# This workflow will install and run the googlefonts/fontbakery QA tool on font build artifacts
+# in the build workflow
+
+name: Font Bakery CI
+
+on: [push, pull_request]
+
+jobs:
+  fontbakery:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Clone build folder
+      uses: actions/checkout@v2
+      with:
+        repository : notofonts/noto-build
+        path : "noto-build"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r "$GITHUB_WORKSPACE"/noto-build/requirements.txt
+    - name: Pull main repository
+      uses: actions/checkout@v2
+      with:
+        path : "main"
+    - name: Build the fonts
+      run: |
+        python "$GITHUB_WORKSPACE"/noto-build/nightlybuild.py
+    - name: Font Bakery CI testing
+      uses: f-actions/font-bakery@v1
+      with:
+        subcmd: "check-notofonts"
+        args: "--loglevel WARN"  # optional additional args to subcmd
+        path: "main/fonts/ttf/unhinted/instance_ttf/*.ttf"
+        version: "latest"  # optional, latest PyPI release is default

--- a/.github/workflows/fontbakery-ci.yml
+++ b/.github/workflows/fontbakery-ci.yml
@@ -31,10 +31,17 @@ jobs:
     - name: Build the fonts
       run: |
         python "$GITHUB_WORKSPACE"/noto-build/nightlybuild.py
-    - name: Font Bakery CI testing
+    - name: Font Bakery CI testing [INSTANCE TTF]
       uses: f-actions/font-bakery@v1
       with:
         subcmd: "check-notofonts"
         args: "--loglevel WARN"  # optional additional args to subcmd
         path: "main/fonts/ttf/unhinted/instance_ttf/*.ttf"
+        version: "latest"  # optional, latest PyPI release is default
+    - name: Font Bakery CI testing [VARIABLE TTF]
+      uses: f-actions/font-bakery@v1
+      with:
+        subcmd: "check-notofonts"
+        args: "--loglevel WARN"  # optional additional args to subcmd
+        path: "main/fonts/ttf/unhinted/variable_ttf/*.ttf"
         version: "latest"  # optional, latest PyPI release is default


### PR DESCRIPTION
This PR adds fontbakery testing with the `check-notofonts` profile using a custom `f-actions/font-bakery` GitHub Action.  As submitted, this filters the fontbakery report on WARN and higher log levels.   It uses the always latest PyPI release version of the fontbakery executable and the rolling v1* semver release of the `f-actions/font-bakery` GitHub Action.  The action source is tested with its own nightly CI and we are using it in a production setting elsewhere.  I intend to avoid breakage... :)  Non-zero exit status codes from fontbakery lead to CI fails.

Docs are available here: https://github.com/f-actions/font-bakery

Let me know if there is anything else that you need.